### PR TITLE
added LeaderRankAlgo for finding key vertices

### DIFF
--- a/src/main/kotlin/graphs/algo/LeaderRank.kt
+++ b/src/main/kotlin/graphs/algo/LeaderRank.kt
@@ -5,22 +5,6 @@ import graphs.primitives.Graph
 import graphs.primitives.Vertex
 import graphs.types.DirectedGraph
 import graphs.types.WeightedDirectedGraph
-
-/*
-
-
-LeaderRank(graph G, damping_factor d, convergence_threshold epsilon)
-1. Инициализируем рейтинги вершин: каждая вершина v_i имеет рейтинг R(v_i) = 1 / |V|, где |V| - общее количество вершин в графе G.
-2. Построим матрицу смежности A графа G.
-3. Построим матрицу переходных вероятностей P: P = A / deg, где deg - количество исходящих ребер для каждой вершины.
-4. Повторяем до сходимости:
-4.1. Вычисляем новые рейтинги вершин: R_new = (1-d) / |V| + d * P * R, где d - коэффициент затухания.
-4.2. Вычисляем изменение в рейтингах: diff = ||R_new - R||
-4.3. Если diff < epsilon, прерываем итерации.
-4.4. Присваиваем R = R_new и продолжаем итерации.
-5. Выводим рейтинги вершин в порядке убывания.
-*/
-
 import kotlin.math.abs
 
 fun <V, E> LeaderRank(G: Graph<V, E>, d: Double, epsilon: Double): List<Pair<Vertex<V>, Double>> {

--- a/src/main/kotlin/graphs/algo/LeaderRank.kt
+++ b/src/main/kotlin/graphs/algo/LeaderRank.kt
@@ -1,0 +1,76 @@
+package graphs.algo
+
+import graphs.primitives.Edge
+import graphs.primitives.Graph
+import graphs.primitives.Vertex
+import graphs.types.DirectedGraph
+import graphs.types.WeightedDirectedGraph
+
+/*
+
+
+LeaderRank(graph G, damping_factor d, convergence_threshold epsilon)
+1. Инициализируем рейтинги вершин: каждая вершина v_i имеет рейтинг R(v_i) = 1 / |V|, где |V| - общее количество вершин в графе G.
+2. Построим матрицу смежности A графа G.
+3. Построим матрицу переходных вероятностей P: P = A / deg, где deg - количество исходящих ребер для каждой вершины.
+4. Повторяем до сходимости:
+4.1. Вычисляем новые рейтинги вершин: R_new = (1-d) / |V| + d * P * R, где d - коэффициент затухания.
+4.2. Вычисляем изменение в рейтингах: diff = ||R_new - R||
+4.3. Если diff < epsilon, прерываем итерации.
+4.4. Присваиваем R = R_new и продолжаем итерации.
+5. Выводим рейтинги вершин в порядке убывания.
+*/
+
+import kotlin.math.abs
+
+fun <V, E> LeaderRank(G: Graph<V, E>, d: Double, epsilon: Double): List<Pair<Vertex<V>, Double>> {
+    val adjacencyList = toAdjacencyList(G)
+    val n = G.vertices.size
+    var R = mutableMapOf<Vertex<V>, Double>()
+    G.vertices.forEach { vertex -> R[vertex] = 1.0 / n }
+
+    val deg = buildOutDegreeMatrix(adjacencyList)
+
+    var diff = Double.MAX_VALUE
+    while (diff >= epsilon) {
+        val R_new = mutableMapOf<Vertex<V>, Double>()
+        G.vertices.forEach { v ->
+            var sum = 0.0
+            G.vertices.forEach { u ->
+                val neighbors = adjacencyList[u.element] ?: mutableSetOf()
+                val weight = neighbors.find { it.first == v.element }?.second?.toDouble() ?: 0.0
+                sum += (d * weight / (deg[u.element]?.toDouble() ?: 1.0)) * (R[u] ?: 0.0)
+            }
+            R_new[v] = (1 - d) / n + sum
+        }
+
+        diff = 0.0
+        G.vertices.forEach { v ->
+            diff += abs(R_new[v]!! - R[v]!!)
+        }
+
+        R = R_new
+    }
+
+    val sortedRatings = R.toList().sortedByDescending { it.second }
+    return sortedRatings
+}
+
+fun <V> buildOutDegreeMatrix(adjacencyList: Map<V, Set<Pair<V, Long?>>>): Map<V, Int> {
+    val deg = mutableMapOf<V, Int>()
+
+    for ((v, neighbors) in adjacencyList) {
+        deg[v] = neighbors.size
+    }
+
+    return deg
+}
+
+fun <V> printAdjacencyMatrix(adjacencyMatrix: Map<Vertex<V>, Map<Vertex<V>, Long?>>) {
+    for ((vertex, neighbors) in adjacencyMatrix) {
+        println("Vertex ${vertex.element}:")
+        for ((neighbor, edge) in neighbors) {
+            println("  Neighbor: ${neighbor.element}, Edge weight: ${edge}")
+        }
+    }
+}

--- a/src/main/kotlin/view/algo/LeaderRankView.kt
+++ b/src/main/kotlin/view/algo/LeaderRankView.kt
@@ -1,0 +1,120 @@
+package view.algo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.*
+
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import graphs.algo.LeaderRank
+import graphs.primitives.Graph
+import io.neo4j.Neo4jRepository
+import viewmodel.MainScreenViewModel
+import viewmodel.graph.GraphViewModel
+
+@Composable
+fun <V, E> LeaderRankDisplay(
+    onDismissRequest: () -> Unit,
+    onResult: (Int?, Double?, Boolean) -> Unit,
+    graph: Graph<V, E>,
+) {
+    var textAmountOfKeyVertices by remember { mutableStateOf("") }
+    var textGapToCheck by remember { mutableStateOf("") }
+    var LeaderRankstart by remember { mutableStateOf(false) }
+
+    Dialog(
+        onDismissRequest = { onDismissRequest() }
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(300.dp),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    "Your graph contains ${graph.vertices.size} vertices",
+                    modifier = Modifier.padding(10.dp),
+                    fontSize = 18.sp
+                )
+
+
+                TextField(
+                    value = textAmountOfKeyVertices,
+                    onValueChange = { textAmountOfKeyVertices = it },
+                    maxLines = 1,
+                    placeholder = { Text("Amount of key vertices:") },
+                    modifier = Modifier.height(50.dp).background(Color.White)
+                )
+                Text("Or")
+                TextField(
+                    value = textGapToCheck,
+                    onValueChange = { textGapToCheck = it },
+                    maxLines = 1,
+                    placeholder = { Text("Vertices with rank higher than:") },
+                    modifier = Modifier.height(50.dp).background(Color.White)
+                )
+
+                if (textAmountOfKeyVertices.isNotEmpty() && textGapToCheck.isNotEmpty()) {
+                    Text("Please enter only one parameter.")
+                }
+
+                if (textAmountOfKeyVertices.isNotEmpty() && textGapToCheck.isEmpty() || textAmountOfKeyVertices.isEmpty() && textGapToCheck.isNotEmpty()) {
+                    Button(
+                        onClick = {
+                            LeaderRankstart = true
+                            val amountOfKeyVertices = textAmountOfKeyVertices.toIntOrNull()
+                            val gapToCheck = textGapToCheck.toDoubleOrNull()
+                            onResult(amountOfKeyVertices, gapToCheck, LeaderRankstart)
+                            onDismissRequest()
+                        }
+                    ) {
+                        Text("Ok")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun <V, E> LeaderRankView(graphViewModel: GraphViewModel<V, E>, topKeys: Int? = 0, gap: Double? = null) {
+    var rankedList = LeaderRank(graphViewModel.graph, d = 0.15, epsilon = 0.008)
+    if (topKeys != null) {
+        rankedList = rankedList.take(topKeys)
+    }
+    else if (gap != null) {
+        rankedList = rankedList.filter{it.second > gap}
+    }
+    rankedList.forEach { topranked ->
+        graphViewModel.vertices.forEach {
+            if (topranked.first.element == it.v.element) {
+                it.color = Color.Red
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
added: parameterizable LeaderRank algorithm
also added visualization for this algorithm
To see the results click "Find Key vertices with leader Rank" button
![image](https://github.com/spbu-coding-2023/graphs-graph-10/assets/74074258/1814d0cf-9a6f-4ccb-9d0c-d25a4f3cc613)
You'll see the dialogue window with parameters to input:
![image](https://github.com/spbu-coding-2023/graphs-graph-10/assets/74074258/c4a8dc3b-e0c9-46a2-b70c-b6970a21fd24)
you may input amount of vertices XOR the gap of ranks to see
after that TopRankedVertices will be coloured with red
![image](https://github.com/spbu-coding-2023/graphs-graph-10/assets/74074258/6e2b0310-831c-4f5b-b413-3fc48a25770e)

the idea of algorithn itself:
LeaderRank(graph G, damping_factor d, convergence_threshold epsilon)
1. Initialize the vertex ratings: each vertex v_i has a rating R(v_i) = 1 / |V|, where |V| is the total number of vertices in graph G.
2. Let's construct the adjacency matrix A of graph G.
3. Let's construct a matrix of transition probabilities P: P = A / deg, where deg is the number of outgoing edges for each vertex.
4. Repeat until convergence:
4.1. Calculate the new vertex ratings: R_new = (1-d) / | V| + d * P * R, where d is the attenuation coefficient.
 4.2. Calculate the change in ratings: diff = ||R_new - R||
4.3. If diff < epsilon, interrupt the iterations.
 4.4. Assign R = R_new and continue iterating.
5. We display the ratings of the vertices in descending order.